### PR TITLE
data split process check for empty dataframe

### DIFF
--- a/intelcamp/buildings_processing.py
+++ b/intelcamp/buildings_processing.py
@@ -252,8 +252,8 @@ def input_data_split(data, configs):
             num_chunks = splicer[-1]
             num_train_chunks = (train_ratio * num_chunks) - ((train_ratio * num_chunks) % configs["train_size_factor"])
             if num_train_chunks == 0:
-                logger.info("Total number of data chunks is zero. train_size_factor value might be too large compared to the data size. Exiting..")
-                sys.exit()
+                raise Exception("Total number of data chunks is zero. train_size_factor value might be too large compared to the data size. Exiting..")
+
             msk = np.zeros(data.shape[0]) + 2
             train_chunks = np.random.choice(np.arange(num_chunks), replace=False, size=int(num_train_chunks))
             for chunk in train_chunks:


### PR DESCRIPTION
I felt like over the past several months, 

- we have found places where empty dataframe was passed to the next steps in the workflow
- and not flagging any issue when an empty dataframe got created
- so felt like it'd be better to have some `if` to check those spots.
- not sure if this is the best approach
- but this is one of them (there might be more coming)
- also related chat is here: https://teams.microsoft.com/l/message/19:caffaa1617874d3aab9ef73c903753f4@thread.skype/1647634610358?tenantId=a0f29d7e-28cd-4f54-8442-7885aee7c080&groupId=a673ac7c-234b-4f92-9636-08629146bfd2&parentMessageId=1647634610358&teamName=Intelligent%20Campus%20Team&channelName=Predictive%20Analytics&createdTime=1647634610358