### PR TITLE
saving measured.h5 along with predictions.h5 for visualization purposes

### DIFF
--- a/wattile/models/algo_main_rnn_v4.py
+++ b/wattile/models/algo_main_rnn_v4.py
@@ -760,10 +760,13 @@ def run_training(  # noqa: C901 TODO: remove no qa
         os.path.join(file_prefix, "residual_distribution.h5"), key="df", mode="w"
     )
 
-    # Save the final predictions to a file
+    # Save the final predictions and measured target to a file
     # predictions.to_csv(file_prefix + '/predictions.csv', index=False)
     pd.DataFrame(predictions).to_hdf(
         os.path.join(file_prefix, "predictions.h5"), key="df", mode="w"
+    )
+    pd.DataFrame(targets.iloc[:, 0]).to_hdf(
+        os.path.join(file_prefix, "measured.h5"), key="df", mode="w"
     )
 
     # Save the QQ information to a file


### PR DESCRIPTION
- I'm working on refactoring feat-eng repo and started to thinking of migrating visualization I had into the Wattile.
- the existing visualization code (https://github.com/NREL/intelligentcampus-feature-eng/blob/develop/visualization.py) I have reads in two files
  - one is already created in Wattile called as `predictions.h5`
  - the other one (called `measured.h5`) is not created in Wattile at the moment, so this PR suggestion is to save that file next to the `predictions.h5` file.
  - `measured.h5` is basically the actual target measurement that represents the validation data `val_df` timestamp, so which aligns completely the same as the timestamp of `predictions.h5`