### PR TITLE
fixing seed number for training

### DIFF
--- a/wattile/models/AlgoMainRNNBase.py
+++ b/wattile/models/AlgoMainRNNBase.py
@@ -5,6 +5,7 @@ from abc import ABC
 from pathlib import Path
 
 import pandas as pd
+import torch
 from torch.utils.tensorboard import SummaryWriter
 
 from wattile.error import ConfigsError
@@ -160,6 +161,9 @@ class AlgoMainRNNBase(ABC):
         run_resume = self.configs["run_resume"]
         tr_desired_batch_size = self.configs["train_batch_size"]
         te_desired_batch_size = self.configs["val_batch_size"]
+
+        # Setting random seed with constant
+        torch.manual_seed(self.configs["random_seed"])
 
         # Create writer object for TensorBoard
         writer_path = str(self.file_prefix)


### PR DESCRIPTION
- coming from https://github.com/NREL/Wattile/issues/133

- probably [this one line](https://github.com/NREL/intelligentcampus-feature-eng/blob/4ed1a379ac59c53226db1553bf5e2a265da25494/algo_main_rnn_v4.py#L794-L795) did not transferred when I was updating training algorithm from feat-eng repo to here

- unsure if the new line is placed in the best place though.

- but test is showing the exact same training performance:
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/JKIM4/AppData/Local/Temp/1/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/JKIM4/AppData/Local/Temp/1/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



File Path | RMSE | CV(RMSE) | NMBE | GOF | QS | ACE | IS | Train time
-- | -- | -- | -- | -- | -- | -- | -- | --
exp_dir | 7.953555 | 0.073451 | 0.003032 | 0.051982 | 1.347989 | 0.688462 | 28.70023 | 11.48954
exp_dir | 7.953555 | 0.073451 | 0.003032 | 0.051982 | 1.347989 | 0.688462 | 28.70023 | 12.95968



</body>

</html>
