### PR TITLE
moving `weight decay`

### DIFF
--- a/tests/fixtures/alfa_exp_dir/configs.json
+++ b/tests/fixtures/alfa_exp_dir/configs.json
@@ -74,7 +74,7 @@
    "val_batch_size": 1,
    "train_val_split": "Random",
    "run_resume": false,
-   "lr_config": {
+   "optimizer_config": {
     "weight_decay": 0.001,
     "base": 0.001,
     "schedule": false,

--- a/tests/fixtures/bravo_exp_dir/configs.json
+++ b/tests/fixtures/bravo_exp_dir/configs.json
@@ -74,7 +74,7 @@
   "val_batch_size": 1,
   "train_val_split": "Random",
   "run_resume": false,
-  "lr_config": {
+  "optimizer_config": {
    "weight_decay": 0.001,
    "base": 0.001,
    "schedule": false,

--- a/tests/fixtures/test_configs.json
+++ b/tests/fixtures/test_configs.json
@@ -74,7 +74,7 @@
    "val_batch_size": 1,
    "train_val_split": "Random",
    "run_resume": false,
-   "lr_config": {
+   "optimizer_config": {
     "weight_decay": 0.001,
     "base": 0.001,
     "schedule": false,

--- a/wattile/configs/configs.json
+++ b/wattile/configs/configs.json
@@ -78,7 +78,7 @@
    "val_batch_size": 1,
    "train_val_split": "Random",
    "run_resume": false,
-   "lr_config": {
+   "optimizer_config": {
     "weight_decay": 0.001,
     "base": 0.001,
     "schedule": false,

--- a/wattile/models/alfa_model.py
+++ b/wattile/models/alfa_model.py
@@ -373,7 +373,7 @@ class AlfaModel(AlgoMainRNNBase):
         """
         num_epochs = num_epochs
         weight_decay = float(
-            self.configs["learning_algorithm"]["lr_config"]["weight_decay"]
+            self.configs["learning_algorithm"]["optimizer_config"]["weight_decay"]
         )
         input_dim = self.configs["input_dim"]
 
@@ -415,47 +415,49 @@ class AlfaModel(AlgoMainRNNBase):
         # Instantiate Optimizer Class
         optimizer = torch.optim.Adam(
             model.parameters(),
-            lr=self.configs["learning_algorithm"]["lr_config"]["base"],
+            lr=self.configs["learning_algorithm"]["optimizer_config"]["base"],
             weight_decay=weight_decay,
         )
 
         # Set up learning rate scheduler
-        if not self.configs["learning_algorithm"]["lr_config"]["schedule"]:
+        if not self.configs["learning_algorithm"]["optimizer_config"]["schedule"]:
             pass
         elif (
-            self.configs["learning_algorithm"]["lr_config"]["schedule"]
-            and self.configs["learning_algorithm"]["lr_config"]["type"] == "performance"
+            self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+            and self.configs["learning_algorithm"]["optimizer_config"]["type"]
+            == "performance"
         ):
             # Patience (for our case) is # of iterations, not epochs,
             # but self.configs specification is num epochs
             scheduler = ReduceLROnPlateau(
                 optimizer,
                 mode="min",
-                factor=self.configs["learning_algorithm"]["lr_config"]["factor"],
-                min_lr=self.configs["learning_algorithm"]["lr_config"]["min"],
+                factor=self.configs["learning_algorithm"]["optimizer_config"]["factor"],
+                min_lr=self.configs["learning_algorithm"]["optimizer_config"]["min"],
                 patience=int(
-                    self.configs["learning_algorithm"]["lr_config"]["patience"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["patience"]
                     * (num_train_data / train_batch_size)
                 ),
                 verbose=True,
             )
         elif (
-            self.configs["learning_algorithm"]["lr_config"]["schedule"]
-            and self.configs["learning_algorithm"]["lr_config"]["type"] == "absolute"
+            self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+            and self.configs["learning_algorithm"]["optimizer_config"]["type"]
+            == "absolute"
         ):
             # scheduler = StepLR(
             #     optimizer,
             #     step_size=int(
-            #         self.configs["learning_algorithm"]["lr_config"]["step_size"]
+            #         self.configs["learning_algorithm"]["optimizer_config"]["step_size"]
             #           * (num_train_data / train_batch_size)
             #     ),
-            #     gamma=self.configs["learning_algorithm"]["lr_config"]["factor"],
+            #     gamma=self.configs["learning_algorithm"]["optimizer_config"]["factor"],
             # )
             pass
         else:
             raise self.configsError(
                 "{} is not a supported method of LR scheduling".format(
-                    self.configs["learning_algorithm"]["lr_config"]["type"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["type"]
                 )
             )
 
@@ -505,18 +507,20 @@ class AlfaModel(AlgoMainRNNBase):
 
             # Do manual learning rate scheduling, if requested
             if (
-                self.configs["learning_algorithm"]["lr_config"]["schedule"]
-                and self.configs["learning_algorithm"]["lr_config"]["type"]
+                self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+                and self.configs["learning_algorithm"]["optimizer_config"]["type"]
                 == "absolute"
                 and epoch_num
-                % self.configs["learning_algorithm"]["lr_config"]["step_size"]
+                % self.configs["learning_algorithm"]["optimizer_config"]["step_size"]
                 == 0
             ):
                 for param_group in optimizer.param_groups:
                     old_lr = param_group["lr"]
                     param_group["lr"] = (
                         param_group["lr"]
-                        * self.configs["learning_algorithm"]["lr_config"]["factor"]
+                        * self.configs["learning_algorithm"]["optimizer_config"][
+                            "factor"
+                        ]
                     )
                     new_lr = param_group["lr"]
                 logger.info(
@@ -572,8 +576,8 @@ class AlfaModel(AlgoMainRNNBase):
                 time5 = timeit.default_timer()
 
                 if (
-                    self.configs["learning_algorithm"]["lr_config"]["schedule"]
-                    and self.configs["learning_algorithm"]["lr_config"]["type"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+                    and self.configs["learning_algorithm"]["optimizer_config"]["type"]
                     == "performance"
                 ):
                     scheduler.step(loss)

--- a/wattile/models/bravo_model.py
+++ b/wattile/models/bravo_model.py
@@ -447,7 +447,7 @@ class BravoModel(AlgoMainRNNBase):
         """
 
         weight_decay = float(
-            self.configs["learning_algorithm"]["lr_config"]["weight_decay"]
+            self.configs["learning_algorithm"]["optimizer_config"]["weight_decay"]
         )
         input_dim = self.configs["input_dim"]
         window_width_target = self.configs["data_processing"]["input_output_window"][
@@ -496,47 +496,49 @@ class BravoModel(AlgoMainRNNBase):
         # Instantiate Optimizer Class
         optimizer = torch.optim.Adam(
             model.parameters(),
-            lr=self.configs["learning_algorithm"]["lr_config"]["base"],
+            lr=self.configs["learning_algorithm"]["optimizer_config"]["base"],
             weight_decay=weight_decay,
         )
 
         # Set up learning rate scheduler
-        if not self.configs["learning_algorithm"]["lr_config"]["schedule"]:
+        if not self.configs["learning_algorithm"]["optimizer_config"]["schedule"]:
             pass
         elif (
-            self.configs["learning_algorithm"]["lr_config"]["schedule"]
-            and self.configs["learning_algorithm"]["lr_config"]["type"] == "performance"
+            self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+            and self.configs["learning_algorithm"]["optimizer_config"]["type"]
+            == "performance"
         ):
             # Patience (for our case) is # of iterations, not epochs,
             # but self.configs specification is num epochs
             scheduler = ReduceLROnPlateau(
                 optimizer,
                 mode="min",
-                factor=self.configs["learning_algorithm"]["lr_config"]["factor"],
-                min_lr=self.configs["learning_algorithm"]["lr_config"]["min"],
+                factor=self.configs["learning_algorithm"]["optimizer_config"]["factor"],
+                min_lr=self.configs["learning_algorithm"]["optimizer_config"]["min"],
                 patience=int(
-                    self.configs["learning_algorithm"]["lr_config"]["patience"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["patience"]
                     * (num_train_data / train_batch_size)
                 ),
                 verbose=True,
             )
         elif (
-            self.configs["learning_algorithm"]["lr_config"]["schedule"]
-            and self.configs["learning_algorithm"]["lr_config"]["type"] == "absolute"
+            self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+            and self.configs["learning_algorithm"]["optimizer_config"]["type"]
+            == "absolute"
         ):
             # scheduler = StepLR(
             #     optimizer,
             #     step_size=int(
-            #         self.configs["learning_algorithm"]["lr_config"]["step_size"]
+            #         self.configs["learning_algorithm"]["optimizer_config"]["step_size"]
             #           * (num_train_data / train_batch_size)
             #     ),
-            #     gamma=self.configs["learning_algorithm"]["lr_config"]["factor"],
+            #     gamma=self.configs["learning_algorithm"]["optimizer_config"]["factor"],
             # )
             pass
         else:
             raise ConfigsError(
                 "{} is not a supported method of LR scheduling".format(
-                    self.configs["learning_algorithm"]["lr_config"]["type"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["type"]
                 )
             )
 
@@ -586,18 +588,20 @@ class BravoModel(AlgoMainRNNBase):
 
             # Do manual learning rate scheduling, if requested
             if (
-                self.configs["learning_algorithm"]["lr_config"]["schedule"]
-                and self.configs["learning_algorithm"]["lr_config"]["type"]
+                self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+                and self.configs["learning_algorithm"]["optimizer_config"]["type"]
                 == "absolute"
                 and epoch_num
-                % self.configs["learning_algorithm"]["lr_config"]["step_size"]
+                % self.configs["learning_algorithm"]["optimizer_config"]["step_size"]
                 == 0
             ):
                 for param_group in optimizer.param_groups:
                     old_lr = param_group["lr"]
                     param_group["lr"] = (
                         param_group["lr"]
-                        * self.configs["learning_algorithm"]["lr_config"]["factor"]
+                        * self.configs["learning_algorithm"]["optimizer_config"][
+                            "factor"
+                        ]
                     )
                     new_lr = param_group["lr"]
                 logger.info(
@@ -653,8 +657,8 @@ class BravoModel(AlgoMainRNNBase):
                 time5 = timeit.default_timer()
 
                 if (
-                    self.configs["learning_algorithm"]["lr_config"]["schedule"]
-                    and self.configs["learning_algorithm"]["lr_config"]["type"]
+                    self.configs["learning_algorithm"]["optimizer_config"]["schedule"]
+                    and self.configs["learning_algorithm"]["optimizer_config"]["type"]
                     == "performance"
                 ):
                     scheduler.step(loss)

--- a/wattile/models/charlie_model.py
+++ b/wattile/models/charlie_model.py
@@ -416,8 +416,10 @@ class CharlieModel:
         window_target_size_count = int(
             pd.Timedelta(window_target_size) / pd.Timedelta(bin_interval)
         )
-        lr = self.configs["learning_algorithm"]["lr_config"]["base"]
-        weight_decay = self.configs["learning_algorithm"]["lr_config"]["weight_decay"]
+        lr = self.configs["learning_algorithm"]["optimizer_config"]["base"]
+        weight_decay = self.configs["learning_algorithm"]["optimizer_config"][
+            "weight_decay"
+        ]
 
         t0 = time.time()
         np.random.seed(seed)


### PR DESCRIPTION
- coming from https://github.com/NREL/Wattile/issues/198

- moving `weight_decay` config param under `lr_config` as it is an input to [torch.optim.Adam](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html#torch.optim.Adam) used in our workflow.

- sanity check: @buechler314 