### PR TITLE
checking device type between GPU/CPU when loading previously trained model

### DIFF
--- a/wattile/models/utils.py
+++ b/wattile/models/utils.py
@@ -61,8 +61,9 @@ def init_model(configs):
 def load_model(configs):
     model = init_model(configs)
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     filepath = pathlib.Path(configs["data_output"]["exp_dir"]) / "torch_model"
-    checkpoint = torch.load(filepath)
+    checkpoint = torch.load(filepath, map_location=device)
 
     model.load_state_dict(checkpoint["model_state_dict"])
     resume_num_epoch = checkpoint["epoch_num"]


### PR DESCRIPTION
- coming from https://github.com/NREL/Wattile/issues/235
- without this change,
  - GPU-trained model cannot be used
  - for prediction on a CPU-only machine
-  we already had a [similar approach](https://github.com/NREL/Wattile/blob/51791b04336695711ca683a804db84754553a355/wattile/buildings_processing.py#L21-L32) when checking on previously incomplete training. so adopting the same approach.

- test result below shows:
  - FTLB model trained with GPU (on HPC) for predicting `FTLB Whole Building Power`
  - downloaded results folder to local computer with CPU only
  - change `use_case` parameter to `validation`
  - change `configs` parameters to match with previously trained model `configs`
  - execute `entry_point.py`
  - output
```
(wattile) C:\Users\jkim4\Documents\GitHub\Wattile>python wattile/entry_point.py
PROJECT_DIRECTORY = C:\Users\jkim4\Anaconda3\envs\wattile\Lib\site-packages\wattile
Logging to: C:\Users\jkim4\OneDrive - NREL\projects\IntCmp\TrainingResults\selected_models\v1\FTLB\FTLB_FTLBWholeBuildingPower_deploy\output.out, PID: 12268
saving timeseries comparison in C:/Users/jkim4/OneDrive - NREL/projects/IntCmp/TrainingResults/selected_models/v1/FTLB/FTLB_FTLBWholeBuildingPower_deploy/Vis_TimeseriesComparisons.svg
```

  - timeseries plot comparison
    - entire look
![image](https://user-images.githubusercontent.com/26775789/204324694-6b756090-2790-4ba8-8338-5163083f4a9d.png)
    - closer look
![image](https://user-images.githubusercontent.com/26775789/204324958-c65c0f7f-12e2-4aa3-bf0d-f899585f2cb3.png)
