### PR TITLE
Use nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 # Install Dependices
 COPY ./poetry.lock /wattile
 COPY ./pyproject.toml /wattile
-RUN pip3 install poetry==1.1.13
+RUN pip3 install poetry==1.5.1
 RUN poetry config virtualenvs.create false
 RUN cd /wattile && poetry install --no-dev
+
+# use non root user. 
+RUN groupadd -r user && useradd -r -g user user
+USER user
 
 ENTRYPOINT ["python"]


### PR DESCRIPTION
I was trying to test this but couldn't figure out how to bash into it. @stephen-frank, does the base image have bash?

```
heslinge at 12:19:34 in ~/Repos/Wattile (run-docker-as-non-root) 
🌟 docker run 2f81bf21e1d4 -it bin/bash
python: can't open file '/usr/src/app/bin/bash': [Errno 2] No such file or directory
>>> 
```