### PR TITLE
Capture wattile version Fixes #322

### DIFF
--- a/wattile/__init__.py
+++ b/wattile/__init__.py
@@ -1,0 +1,10 @@
+import toml
+from os import path
+
+b_path = path.dirname(__file__)
+proj_path = path.abspath(path.join(b_path, '..', 'pyproject.toml'))
+
+with open(proj_path, 'r') as f:
+    config = toml.load(f)
+    version = config['tool']['poetry']['version']
+

--- a/wattile/__init__.py
+++ b/wattile/__init__.py
@@ -1,10 +1,10 @@
-import toml
 from os import path
 
+import toml
+
 b_path = path.dirname(__file__)
-proj_path = path.abspath(path.join(b_path, '..', 'pyproject.toml'))
+proj_path = path.abspath(path.join(b_path, "..", "pyproject.toml"))
 
-with open(proj_path, 'r') as f:
+with open(proj_path, "r") as f:
     config = toml.load(f)
-    version = config['tool']['poetry']['version']
-
+    version = config["tool"]["poetry"]["version"]

--- a/wattile/entry_point.py
+++ b/wattile/entry_point.py
@@ -4,10 +4,10 @@ import os
 import pathlib
 
 import pandas as pd
-
 import wattile.data_processing as bp
 from wattile.data_reading import read_dataset_from_file
 from wattile.models import ModelFactory
+from wattile import version as wattile_version
 
 PACKAGE_PATH = pathlib.Path(__file__).parent
 CONFIGS_PATH = PACKAGE_PATH / "configs" / "configs.json"
@@ -35,6 +35,7 @@ def init_logging(local_results_dir):
     logger.addHandler(hdlr)
     logger.setLevel(logging.INFO)
     logger.info("PID: {}".format(PID))
+    logger.info("Trained with Wattile version: {}".format(wattile_version))
 
 
 def create_input_dataframe(configs):

--- a/wattile/entry_point.py
+++ b/wattile/entry_point.py
@@ -4,10 +4,11 @@ import os
 import pathlib
 
 import pandas as pd
+
 import wattile.data_processing as bp
+from wattile import version as wattile_version
 from wattile.data_reading import read_dataset_from_file
 from wattile.models import ModelFactory
-from wattile import version as wattile_version
 
 PACKAGE_PATH = pathlib.Path(__file__).parent
 CONFIGS_PATH = PACKAGE_PATH / "configs" / "configs.json"

--- a/wattile/models/base_model.py
+++ b/wattile/models/base_model.py
@@ -8,6 +8,7 @@ import pandas as pd
 import torch
 from torch.utils.tensorboard import SummaryWriter
 
+from wattile import version as wattile_version
 from wattile.error import ConfigsError
 from wattile.util import factors
 from wattile.visualization import timeseries_comparison
@@ -126,6 +127,13 @@ class BaseModel(ABC):
 
         return data
 
+    def write_metadata(self):
+        """Write the metadata to a json file"""
+        path = os.path.join(self.file_prefix, "metadata.json")
+        metadata = {"wattile_version": wattile_version}
+        with open(path, "w") as fp:
+            json.dump(metadata, fp, indent=1)
+
     def main(self, train_df, val_df):
         """
         Main executable for prepping data for input to RNN model.
@@ -161,6 +169,7 @@ class BaseModel(ABC):
         val_loader = self.to_data_loader(val_data, val_batch_size, shuffle=True)
 
         self.run_training(train_loader, val_loader, val_df)
+        self.write_metadata()
 
         # Create visualization
         if self.configs["data_output"]["plot_comparison"]:


### PR DESCRIPTION
Captures the current version of Wattile via `wattile.version`

Updates the current output.out artifact to add the Wattile version used during training (example below)

```
07/23/2024 09:41:45 - INFO     - PID: 29092
07/23/2024 09:41:45 - INFO     - Trained with Wattile version: 0.2.0
07/23/2024 09:41:45 - INFO     - AlfaModel model created.Writing to /Users/jsmith2/Code/@ic/Wattile/notebooks/examples/exp_dir.
07/23/2024 09:41:46 - INFO     - Available train batch factors: [1, 2, 7, 14, 37, 74, 259, 518]Requested number of batches per epoch - Train:                 26, val: 1Actual number of batches per epoch - Train:                 37, val: 1Number of data samples in each batch - Train: 14, val: 130
07/23/2024 09:41:46 - INFO     - A new lstm RNN model instantiated
07/23/2024 09:41:46 - INFO     - Number of cores available: 10
07/23/2024 09:41:46 - INFO     - Number of logical processors available: 10
07/23/2024 09:41:46 - INFO     - Initial memory statistics (GB): {'total': 68.719476736, 'available': 8.685211648, 'percent': 87.4, 'used': 8.178655232, 'free': 1.508171776}
07/23/2024 09:41:46 - INFO     - Starting to train the model for 100 epochs!
07/23/2024 09:41:50 - INFO     - Epoch: 14 Iteration: 500. Train_loss: 0.03660201653838158. val_loss: 0.028353305533225386, LR: 0.001
07/23/2024 09:41:54 - INFO     - Epoch: 28 Iteration: 1000. Train_loss: 0.020166121423244476. val_loss: 0.0287508123432047, LR: 0.001
07/23/2024 09:41:59 - INFO     - Epoch: 41 Iteration: 1500. Train_loss: 0.0174389760941267. val_loss: 0.02968014141083662, LR: 0.001
07/23/2024 09:42:03 - INFO     - Epoch: 55 Iteration: 2000. Train_loss: 0.019406646490097046. val_loss: 0.03064489169517134, LR: 0.001
07/23/2024 09:42:07 - INFO     - Epoch: 68 Iteration: 2500. Train_loss: 0.01951831579208374. val_loss: 0.03150215974338796, LR: 0.001
07/23/2024 09:42:11 - INFO     - Epoch: 82 Iteration: 3000. Train_loss: 0.016622301191091537. val_loss: 0.030752943299107844, LR: 0.001
07/23/2024 09:42:15 - INFO     - Epoch: 95 Iteration: 3500. Train_loss: 0.012720693834125996. val_loss: 0.031284728913531686, LR: 0.001
```

Note: this branch was created on top of the `Update-torch` branch. That branch should be merged first and I will update this branch if needed pre merge.